### PR TITLE
Add `-E` flag to `make install`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM cloudposse/terraform-root-modules:0.4.8 as terraform-root-modules
+FROM cloudposse/terraform-root-modules:0.5.3 as terraform-root-modules
 
-FROM cloudposse/geodesic:0.11.6
+FROM cloudposse/geodesic:0.13.2
 
 ENV DOCKER_IMAGE="cloudposse/audit.cloudposse.co"
 ENV DOCKER_TAG="latest"

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ export DOCKER_ORG ?= cloudposse
 export DOCKER_IMAGE ?= $(DOCKER_ORG)/$(CLUSTER)
 export DOCKER_TAG ?= latest
 export DOCKER_IMAGE_NAME ?= $(DOCKER_IMAGE):$(DOCKER_TAG)
-export DOCKER_BUILD_FLAGS = 
+export DOCKER_BUILD_FLAGS =
 export README_DEPS ?= docs/targets.md docs/terraform.md
 export INSTALL_PATH ?= /usr/local/bin
 
@@ -27,7 +27,7 @@ push:
 
 ## Install wrapper script from geodesic container
 install:
-	@docker run --rm $(DOCKER_IMAGE_NAME) | sudo bash -s $(DOCKER_TAG)
+	@docker run --rm $(DOCKER_IMAGE_NAME) | sudo -E bash -s $(DOCKER_TAG)
 
 ## Start the geodesic shell by calling wrapper script
 run:


### PR DESCRIPTION
## what
* Add `-E` flag to `make install`

## why
* Required on Windows Subsystem for Linux (WSL)
* Indicates to the security policy that the user wishes to preserve their existing environment variables
